### PR TITLE
Respect Tradeability

### DIFF
--- a/common/src/main/java/io/github/polymeta/pokegift/commands/Gift.java
+++ b/common/src/main/java/io/github/polymeta/pokegift/commands/Gift.java
@@ -114,7 +114,7 @@ public class Gift {
                 return true;
             }
         }
-        return false;
+        return pokemon.getTradeable();
     }
 
 }


### PR DESCRIPTION
Currently non-tradeable pokemon can be gifted, this PR resolves this issue.